### PR TITLE
refactor: Usa TrueForAll en validación de jugadores de torneo y añade documentación

### DIFF
--- a/Documentation/About Refactors/re01-TournamentPlayerValidationOptimization (v.01).md
+++ b/Documentation/About Refactors/re01-TournamentPlayerValidationOptimization (v.01).md
@@ -1,0 +1,26 @@
+# Refactorización: Optimización en Validación de Jugadores del Torneo
+
+- **Versión:** 01
+- **Fecha:** 2025-05-20
+- **Autor:** Miguel Ángel
+
+## Índice
+
+- [Refactorización: Optimización en Validación de Jugadores del Torneo](#refactorización-optimización-en-validación-de-jugadores-del-torneo)
+  - [Índice](#índice)
+  - [Descripción del Cambio](#descripción-del-cambio)
+  - [Justificación](#justificación)
+  - [Impacto](#impacto)
+
+## Descripción del Cambio
+
+Se ha refactorizado el método `ValidatePlayers` dentro de la entidad `Tournament.cs`.
+El cambio consiste en reemplazar el uso del método LINQ `.All()` por el método `.TrueForAll()` específico de `List<T>` para la validación del género de los jugadores según el tipo de torneo.
+
+## Justificación
+
+Aunque funcionalmente ambos métodos logran el mismo objetivo, `.TrueForAll()` puede ofrecer una ligera ventaja de rendimiento al operar directamente sobre la estructura de `List<T>` y evita la sobrecarga de los métodos de extensión LINQ en este contexto específico. Este cambio también sirve como ejemplo de micro-optimización y preferencia estilística.
+
+## Impacto
+
+No se espera impacto funcional. Las pruebas unitarias existentes que cubren esta lógica deben seguir pasando.

--- a/src/TennisTournament.Domain/Entities/Tournament.cs
+++ b/src/TennisTournament.Domain/Entities/Tournament.cs
@@ -169,8 +169,8 @@ namespace TennisTournament.Domain.Entities
 
             // Verificar que los jugadores sean del tipo correcto según el torneo
             bool allPlayersValid = type == TournamentType.Male
-                ? players.All(p => p.PlayerType == PlayerType.Male)
-                : players.All(p => p.PlayerType == PlayerType.Female);
+                ? players.TrueForAll(p => p.PlayerType == PlayerType.Male)
+                : players.TrueForAll(p => p.PlayerType == PlayerType.Female);
 
             if (!allPlayersValid)
                 throw new ArgumentException($"Todos los jugadores deben ser del tipo {type}.", nameof(players));


### PR DESCRIPTION
## Descripción del Cambio

Se ha refactorizado el método `ValidatePlayers` dentro de la entidad `Tournament.cs`.
El cambio consiste en reemplazar el uso del método LINQ `.All()` por el método `.TrueForAll()` específico de `List<T>` para la validación del género de los jugadores según el tipo de torneo.